### PR TITLE
ci: Add ability to skip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   build:
     name: build
+    if: >
+      github.event_name == 'pull_request' ||
+      github.event_name == 'push' &&
+      (!contains(toJson(github.event.commits), '[ci skip]')) &&
+      (!contains(toJson(github.event.commits), '[skip ci]'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Adding `[skip ci]` or `[ci skip]` will allow CI to not run on push events.