### PR TITLE
refactor: use lodash.memoize for log cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "engines": {
     "node": ">=10"
   },
+  "dependencies": {
+    "lodash.memoize": "^4.1.2"
+  },
   "devDependencies": {
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",

--- a/src/function-value-plugin.js
+++ b/src/function-value-plugin.js
@@ -1,10 +1,10 @@
+import memoize from 'lodash.memoize';
 import { name } from '../package.json';
 
 const defaultVariableResolverOptions = {
   serviceName: name,
   isDisabledAtPrepopulation: true
 };
-const logged = {};
 
 const format = (value, result) =>
   `[${name}] \${${value}} => ${JSON.stringify(result)}`;
@@ -14,13 +14,9 @@ export class FunctionValuePlugin {
     if (!process.env.SLS_DEBUG) {
       this._log = () => { };
     } else {
-      this._log = (value, result) => {
-        if (!logged[value]) {
-          logged[value] = true;
+      const log = (value, result) => serverless.cli.log(format(value, result));
 
-          serverless.cli.log(format(value, result));
-        }
-      };
+      this._log = memoize(log);
     }
 
     this._naming = serverless.getProvider('aws').naming;


### PR DESCRIPTION
Instead of rolling our own basic caching use `lodash.memoize`. It is a minimal dependency and makes the code cleaner.