### PR TITLE
build(release): change tag format

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,4 @@
 {
-  "tagFormat": "${version}",
   "branches": ["main"],
   "plugins": [
     [


### PR DESCRIPTION
Switch from `X.Y.Z` to `vX.Y.Z`. Manually update all old releases.