### PR TITLE
build(commitlint): enable linting of commits

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,25 @@
+{
+    "extends": [
+        "@commitlint/config-conventional"
+    ],
+    "rules": {
+        "type-enum": [
+            2,
+            "always",
+            [
+                "feat",
+                "fix",
+                "perf",
+                "revert",
+                "docs",
+                "chore",
+                "refactor",
+                "test",
+                "build"
+            ]
+        ],
+        "header-max-length": [2, "always", 50],
+        "body-max-line-length": [2, "always", 80],
+        "footer-max-line-length": [2, "always", 80]
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "babel --out-dir dist src",
     "lint": "eslint .",
     "format": "npm run lint -s -- --fix",
+    "pretest": "commitlint --from origin/main --to HEAD",
     "test": "npm run lint -s && nyc mocha --colors"
   },
   "repository": {
@@ -42,6 +43,8 @@
     "@babel/core": "^7.11.6",
     "@babel/preset-env": "^7.11.5",
     "@babel/register": "^7.11.5",
+    "@commitlint/cli": "^11.0.0",
+    "@commitlint/config-conventional": "^11.0.0",
     "@semantic-release/git": "^9.0.0",
     "babel-plugin-add-module-exports": "^1.0.4",
     "chai": "^4.2.0",


### PR DESCRIPTION
This will help enforce standards. Add to npm test command.