### PR TITLE
build: checkout branch that ci ran on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
     - cron: '0 19 * * *'
   workflow_run:
     workflows: CI
-    branches: main
     types: completed
+    branches: main
 permissions:
   contents: read
 concurrency: release
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
         with:
+          ref: ${{github.event.workflow_run.head_branch}}
           persist-credentials: false
       - name: Get node version
         id: node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,10 @@ on:
   workflow_run:
     workflows: CI
     types: completed
-    branches: main
+    branches:
+      - main
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+.x'
 permissions:
   contents: read
 concurrency: release


### PR DESCRIPTION
This will be needed for maintenance branches.