### PR TITLE
chore: pin actions to major version where available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -33,9 +33,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
       - name: Set up node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -46,7 +46,7 @@ jobs:
       - name: Run tests (integration)
         run:  npm run test:integration
       - name: Report coverage
-        uses: coverallsapp/github-action@v2.3.7
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{github.token}}
   build:
@@ -55,9 +55,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
       - name: Set up node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,4 +23,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Apply labels
-        uses: actions/labeler@v6.1.0
+        uses: actions/labeler@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -36,7 +36,7 @@ jobs:
         run: npm run build
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{secrets.GH_APP_CLIENT_ID}}
           private-key: ${{secrets.GH_APP_PRIVATE_KEY}}

--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -18,7 +18,7 @@ jobs:
       REGEX: ^(Copyright \(c\) )[0-9]{4}( Devon Powell)$
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
       - name: Determine info
         shell: bash
         id: info
@@ -36,7 +36,7 @@ jobs:
           LICENSE_YEAR: ${{steps.info.outputs.license-year}}
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{secrets.GH_APP_CLIENT_ID}}
           private-key: ${{secrets.GH_APP_PRIVATE_KEY}}
@@ -54,7 +54,7 @@ jobs:
           GH_APP_SLUG: ${{steps.app-token.outputs.app-slug}}
           GH_TOKEN: ${{steps.app-token.outputs.token}}
       - name: Handle changes
-        uses: peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@v8
         id: changes
         with:
           token: ${{steps.app-token.outputs.token}}

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
       - name: Determine info
         shell: bash
         id: info
@@ -42,7 +42,7 @@ jobs:
           NODE_VERSION: ${{steps.info.outputs.version}}
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{secrets.GH_APP_CLIENT_ID}}
           private-key: ${{secrets.GH_APP_PRIVATE_KEY}}
@@ -60,7 +60,7 @@ jobs:
           GH_APP_SLUG: ${{steps.app-token.outputs.app-slug}}
           GH_TOKEN: ${{steps.app-token.outputs.token}}
       - name: Handle changes
-        uses: peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@v8
         id: changes
         with:
           token: ${{steps.app-token.outputs.token}}


### PR DESCRIPTION
Pin GitHub Actions to their major version where a major tag is available.